### PR TITLE
Fix import header

### DIFF
--- a/CircularScrollInertiaDemo/RDDRotationControlSurface.h
+++ b/CircularScrollInertiaDemo/RDDRotationControlSurface.h
@@ -32,8 +32,7 @@
 //  Information about the angle and rotation is then sent to a delegate object.
 /*****************************************************************/
 
-#import <Foundation/Foundation.h>
-
+#import <UIKit/UIKit.h>
 
 @protocol RDDRotationControlSurfaceDelegate <NSObject>
 @optional


### PR DESCRIPTION
Needs to import UIKit instead of Foundation if UIKit is not in the project's prefix headers.
